### PR TITLE
배상정보 엔티티를 생성하라

### DIFF
--- a/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
@@ -1,0 +1,35 @@
+package teamfresh.api.application.compensation.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+/** 배상정보 엔티티 */
+@Getter
+@Entity
+public class Compensation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private int amount;
+
+    protected Compensation() {
+    }
+
+    private Compensation(final Long id, final int amount) {
+        this.id = id;
+        this.amount = amount;
+    }
+
+    public static Compensation of(Long id, int amount) {
+        return new Compensation(id, amount);
+    }
+
+    public static Compensation of(int amount) {
+        return new Compensation(null, amount);
+    }
+}

--- a/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
@@ -1,0 +1,6 @@
+package teamfresh.api.application.compensation.domain;
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface CompensationRepository extends CrudRepository<Compensation, Long> {
+}


### PR DESCRIPTION
배상정보를 관리하는 `Compensation` 엔티티와 리포지토리를 생성합니다.

현재는 배상 금액인 `amount` 속성만 가지고 있습니다.