### PR TITLE
VOC 엔티티의 정적 팩터리메서드를 변경 및 추가하라

### DIFF
--- a/src/main/java/teamfresh/api/application/voc/domain/Voc.java
+++ b/src/main/java/teamfresh/api/application/voc/domain/Voc.java
@@ -57,8 +57,12 @@ public class Voc {
         return new Voc(null, content, null, null, null, createdBy);
     }
 
-    public static Voc withBlame(String content, Blame blame, Long customerManagerId, Long createdBy) {
-        return new Voc(0L, content, blame, null, customerManagerId, createdBy);
+    public static Voc of(String content, Blame blame, Long customerManagerId, Long createdBy) {
+        return new Voc(null, content, blame, null, customerManagerId, createdBy);
+    }
+
+    public static Voc of(Long id, String content, Blame blame, Long customerManagerId, Long createdBy) {
+        return new Voc(id, content, blame, null, customerManagerId, createdBy);
     }
 
     /**

--- a/src/main/java/teamfresh/api/application/voc/service/VocCreator.java
+++ b/src/main/java/teamfresh/api/application/voc/service/VocCreator.java
@@ -1,7 +1,6 @@
 package teamfresh.api.application.voc.service;
 
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,7 +27,7 @@ public class VocCreator {
     @Transactional
     public Voc create(Command command) {
         return repository.save(
-                Voc.withBlame(
+                Voc.of(
                         command.content,
                         blameCreator.create(command.target, command.cause),
                         command.customerManagerId,

--- a/src/test/java/teamfresh/api/application/voc/service/VocCreatorTest.java
+++ b/src/test/java/teamfresh/api/application/voc/service/VocCreatorTest.java
@@ -41,7 +41,7 @@ class VocCreatorTest {
         Long customerManagerId = 9L;
 
         Blame blame = Blame.of(1L, target, cause);
-        Voc voc = Voc.withBlame(content, blame, customerManagerId, createdBy);
+        Voc voc = Voc.of(1L, content, blame, customerManagerId, createdBy);
 
         @DisplayName("VOC를 생성 후 반환한다")
         @Test


### PR DESCRIPTION
withBlame이라는 팩터리메서드를 of로 변경합니다.
테스트에서 사용하기 위한 id가 포함된 정적 팩터리메서드를 추가합니다.