### PR TITLE
VOC 단건 조회 서비스를 작성하라

### DIFF
--- a/src/main/java/teamfresh/api/application/voc/exception/VocNotFoundException.java
+++ b/src/main/java/teamfresh/api/application/voc/exception/VocNotFoundException.java
@@ -1,0 +1,19 @@
+package teamfresh.api.application.voc.exception;
+
+/** VOC를 찾지 못한 경우 던짐 */
+public class VocNotFoundException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "VOC를 찾을 수 없습니다.";
+
+    public VocNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public VocNotFoundException(final String message) {
+        super(message);
+    }
+
+    public VocNotFoundException(final Long id) {
+        super(String.format("%s에 해당하는 Voc를 찾을 수 없습니다.", id));
+    }
+}

--- a/src/main/java/teamfresh/api/application/voc/service/VocReader.java
+++ b/src/main/java/teamfresh/api/application/voc/service/VocReader.java
@@ -1,0 +1,31 @@
+package teamfresh.api.application.voc.service;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.domain.VocRepository;
+import teamfresh.api.application.voc.exception.VocNotFoundException;
+
+/** VOC 조회 담당 */
+@Service
+public class VocReader {
+
+    private final VocRepository repository;
+
+    public VocReader(final VocRepository repository) {
+        this.repository = repository;
+    }
+
+    /**
+     * 주어진 식별자로 찾은 VOC를 반환합니다.
+     *
+     * @param id VOC 식별자
+     * @return 식별자로 조회한 VOC
+     * @throws VocNotFoundException 식별자로 VOC를 찾지 못한 경우 던짐
+     */
+    @Transactional(readOnly = true)
+    public Voc read(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new VocNotFoundException(id));
+    }
+}

--- a/src/test/java/teamfresh/api/application/voc/service/VocReaderTest.java
+++ b/src/test/java/teamfresh/api/application/voc/service/VocReaderTest.java
@@ -1,0 +1,74 @@
+package teamfresh.api.application.voc.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.domain.VocRepository;
+import teamfresh.api.application.voc.exception.VocNotFoundException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class VocReaderTest {
+
+    @InjectMocks
+    private VocReader vocReader;
+
+    @Mock
+    private VocRepository repository;
+
+    @DisplayName("read 메서드")
+    @Nested
+    class Describe_of_read {
+
+        Long id = 72L;
+        String content = "voc content";
+        Long createdBy = 11L;
+
+        @BeforeEach
+        void setUp() {
+            given(repository.findById(id))
+                    .willReturn(Optional.of(Voc.of(id, content, createdBy)));
+        }
+
+        @DisplayName("주어진 VOC id로 VOC를 찾을 수 있으면")
+        @Nested
+        class Context_with_exist_id {
+            @DisplayName("VOC를 반환한다")
+            @Test
+            void It_will_return_voc() {
+                Voc voc = vocReader.read(id);
+
+                assertThat(voc).isNotNull();
+                assertThat(voc.getId()).isEqualTo(id);
+            }
+        }
+
+        @DisplayName("찾을 수 없는 VOC id가 주어지면")
+        @Nested
+        class Context_with_not_exist_id {
+
+            @BeforeEach
+            void setUp() {
+                given(repository.findById(id))
+                        .willReturn(Optional.empty());
+            }
+
+            @DisplayName("VocNotFoundException을 던진다")
+            @Test
+            void it_throws_voc_not_found_exception() {
+                assertThrows(VocNotFoundException.class, () -> vocReader.read(id));
+            }
+        }
+    }
+}


### PR DESCRIPTION
VOC 식별자인 `id`로 VOC를 조회하는 서비스인 `VocReader`클래스를 만들었습니다.
주어진 `id`로 VOC를 찾지 못할 경우 `VocNotFoundException`을 던집니다.