### PR TITLE
배상 정보 조회 서비스를 작성하라

### DIFF
--- a/src/main/java/teamfresh/api/application/compensation/exception/CompensationNotFoundException.java
+++ b/src/main/java/teamfresh/api/application/compensation/exception/CompensationNotFoundException.java
@@ -1,0 +1,14 @@
+package teamfresh.api.application.compensation.exception;
+
+public class CompensationNotFoundException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "배상 정보를 찾을 수 없습니다.";
+
+    public CompensationNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    public CompensationNotFoundException(final Long id) {
+        super(String.format("%s에 해당하는 배상 정보를 찾을 수 없습니다.", id));
+    }
+}

--- a/src/main/java/teamfresh/api/application/compensation/service/CompensationReader.java
+++ b/src/main/java/teamfresh/api/application/compensation/service/CompensationReader.java
@@ -1,0 +1,29 @@
+package teamfresh.api.application.compensation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.domain.CompensationRepository;
+import teamfresh.api.application.compensation.exception.CompensationNotFoundException;
+
+/** 배상 정보 조회 담당 */
+@RequiredArgsConstructor
+@Service
+public class CompensationReader {
+
+    private final CompensationRepository repository;
+
+    /**
+     * 주어진 id에 해당하는 배상 정보를 조회 후 반환합니다.
+     *
+     * @param id 배상 정보 id
+     * @return 배상 정보
+     * @throws CompensationNotFoundException 주어진 id로 배상 정보를 찾을 수 없는 경우 던짐
+     */
+    @Transactional(readOnly = true)
+    public Compensation read(Long id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new CompensationNotFoundException(id));
+    }
+}

--- a/src/test/java/teamfresh/api/application/compensation/service/CompensationReaderTest.java
+++ b/src/test/java/teamfresh/api/application/compensation/service/CompensationReaderTest.java
@@ -1,0 +1,77 @@
+package teamfresh.api.application.compensation.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.domain.CompensationRepository;
+import teamfresh.api.application.compensation.exception.CompensationNotFoundException;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CompensationReaderTest {
+
+    @InjectMocks
+    private CompensationReader compensationReader;
+
+    @Mock
+    private CompensationRepository repository;
+
+    @DisplayName("read 메서드")
+    @Nested
+    class Describe_of_read {
+
+        Long id = 1L;
+        int amount = 30000;
+
+        @DisplayName("주어진 id로 배상 정보를 찾을 수 있으면")
+        @Nested
+        class Context_with_exist_id {
+
+            @BeforeEach
+            void setUp() {
+                given(repository.findById(id))
+                        .willReturn(Optional.of(Compensation.of(id, amount)));
+            }
+
+            @DisplayName("배상 정보를 반환한다")
+            @Test
+            void it_returns_compensation() {
+                Compensation compensation = compensationReader.read(id);
+
+                assertThat(compensation).isNotNull();
+                assertThat(compensation.getId()).isEqualTo(id);
+                assertThat(compensation.getAmount()).isEqualTo(amount);
+            }
+        }
+
+        @DisplayName("주어진 id로 배상 정보를 찾지 못하면")
+        @Nested
+        class Context_with_not_exist_id {
+
+            @BeforeEach
+            void setUp() {
+                given(repository.findById(id))
+                        .willReturn(Optional.empty());
+            }
+
+            @DisplayName("CompensationNotFoundException을 던진다")
+            @Test
+            void it_throws_compensation_not_found_exception() {
+                assertThrows(CompensationNotFoundException.class,
+                        () -> compensationReader.read(id));
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
배상 정보 id가 주어지면 id에 해당하는 배상 정보를 조회 후 반환하는 서비스를 만들었습니다.
만약 주어진 id로 배상 정보를 찾을 수 없을 경우, `CompensationNotFoundException`을 던집니다.