### PR TITLE
VOC 생성 요청 컨트롤러를 작성하라

### DIFF
--- a/src/main/java/teamfresh/api/web/vocs/VocCreateController.java
+++ b/src/main/java/teamfresh/api/web/vocs/VocCreateController.java
@@ -1,0 +1,60 @@
+package teamfresh.api.web.vocs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import teamfresh.api.application.voc.blame.domain.BlameTarget;
+import teamfresh.api.application.voc.service.VocCreator;
+
+/** VOC 생성 요청 담당 */
+@RequiredArgsConstructor
+@RequestMapping("/vocs")
+@RestController
+public class VocCreateController {
+
+    private final VocCreator vocCreator;
+
+    /**
+     * VOC 생성 요청데이터를 받아 VOC를 생성 합니다.
+     * 생성된 VOC의 id를 응답합니다.
+     *
+     * @param request VOC 생성 요청 객체
+     * @return 생성된 VOC의 id
+     */
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Response handleVocCreate(@RequestBody Request request) {
+        VocCreator.Command command = new VocCreator.Command(
+                request.getContent(),
+                request.getTarget(),
+                request.getCause(),
+                request.getCustomerManagerId(),
+                request.getCreatedBy()
+        );
+        return new Response(vocCreator.create(command).getId());
+    }
+
+    /** VOC 생성 요청 객체 */
+    @Getter
+    @AllArgsConstructor
+    public static class Request {
+        private String content;
+        private BlameTarget target;
+        private String cause;
+        private Long customerManagerId;
+        private Long createdBy;
+    }
+
+    /** VOC 생성 응답 객체 */
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        private Long id;
+    }
+}

--- a/src/test/java/teamfresh/api/web/vocs/VocCreateControllerMvcTest.java
+++ b/src/test/java/teamfresh/api/web/vocs/VocCreateControllerMvcTest.java
@@ -1,0 +1,73 @@
+package teamfresh.api.web.vocs;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import teamfresh.api.application.voc.blame.domain.BlameTarget;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.service.VocCreator;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(VocCreateController.class)
+public class VocCreateControllerMvcTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private VocCreator vocCreator;
+
+    @DisplayName("POST /vocs")
+    @Nested
+    class Describe_post_vocs {
+
+        Long vocId = 8L;
+        String content = "voc content";
+        BlameTarget target = BlameTarget.CARRIER;
+        String cause = "blame cause";
+        Long customerManagerId = 33L;
+        Long createdBy = 1L;
+
+        @BeforeEach
+        void setUp() {
+            given(vocCreator.create(any()))
+                    .willReturn(Voc.of(vocId, content, createdBy));
+        }
+
+        @DisplayName("201 Created 상태코드와 함께 생성된 VOC id를 응답한다")
+        @Test
+        void it_response_voc_id_with_201_status() throws Exception {
+            VocCreateController.Request request = new VocCreateController.Request(
+                    content, target, cause, customerManagerId, createdBy
+            );
+
+            mvc.perform(
+                    post("/vocs")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(toJSON(request))
+            ).andExpectAll(
+                    status().isCreated(),
+                    jsonPath("$.id").isNumber(),
+                    jsonPath("$.id").value(vocId)
+            );
+        }
+    }
+
+    private String toJSON(Object object) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(object);
+    }
+}

--- a/src/test/java/teamfresh/api/web/vocs/VocCreateControllerTest.java
+++ b/src/test/java/teamfresh/api/web/vocs/VocCreateControllerTest.java
@@ -1,0 +1,64 @@
+package teamfresh.api.web.vocs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.voc.blame.domain.BlameTarget;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.service.VocCreator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class VocCreateControllerTest {
+
+    @InjectMocks
+    private VocCreateController vocCreateController;
+
+    @Mock
+    private VocCreator vocCreator;
+
+    @DisplayName("handleVocCreate 메서드")
+    @Nested
+    class Describe_handle_voc_create {
+
+        Long vocId = 8L;
+        String content = "voc content";
+        BlameTarget target = BlameTarget.CARRIER;
+        String cause = "blame cause";
+        Long customerManagerId = 33L;
+        Long createdBy = 1L;
+
+        @BeforeEach
+        void setUp() {
+            given(vocCreator.create(any()))
+                    .willReturn(Voc.of(vocId, content, createdBy));
+        }
+
+        @DisplayName("VOC 생성 요청 데이터가 주어지면")
+        @Nested
+        class Context_with_voc_create_request_data {
+            @DisplayName("생성된 VOC의 id를 반환한다")
+            @Test
+            void it_return_voc_id() {
+                //given
+                VocCreateController.Request request = new VocCreateController.Request(
+                        content, target, cause, customerManagerId, createdBy
+                );
+
+                //when
+                VocCreateController.Response response = vocCreateController.handleVocCreate(request);
+
+                //then
+                assertThat(response.getId()).isEqualTo(vocId);
+            }
+        }
+    }
+}


### PR DESCRIPTION
VOC 생성 요청을 받아 처리하는 `VoCCreateController`를 만들었습니다.
성공적으로 생성하면 생성된 VOC의 id를 응답합니다.

```
// Request
POST /vocs

{
	"content": "배송 받은 물건이 파손되어있다고 클레임이 들어옴",
	"target": "CARRIER",
	"cause": "배송 기사님 실수로 인한 박스 훼손으로 인한 파손",
	"compenstation": 100000
}

// Response
201 Created
{
	"id": 1
}
```