### PR TITLE
배상정보 등록 컨트롤러를 작성하라

### DIFF
--- a/src/main/java/teamfresh/api/web/vocs/compensations/CompensationsCreateController.java
+++ b/src/main/java/teamfresh/api/web/vocs/compensations/CompensationsCreateController.java
@@ -1,0 +1,56 @@
+package teamfresh.api.web.vocs.compensations;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import teamfresh.api.application.compensation.service.CompensationCreator;
+
+/** 배상 정보 등록 요청 담당 */
+@RequiredArgsConstructor
+@RequestMapping("/vocs/{vocId}/compensations")
+@RestController
+public class CompensationsCreateController {
+
+    private final CompensationCreator compensationCreator;
+
+    /**
+     * VOC 건에 해당하는 배상 정보를 등록한 후 배상 정보의 id를 응답합니다.
+     *
+     * @param vocId 배상 정보를 등록할 VOC의 id
+     * @param request 배상 정보 등록 요청 객체
+     * @return 생성된 배상정보의 id
+     */
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Response handleCompensationCreate(
+            @PathVariable Long vocId,
+            @RequestBody Request request
+    ) {
+        return new Response(
+                compensationCreator.create(vocId, request.getAmount()).getId()
+        );
+    }
+
+    /** 배상 정보 생성 요청 객체 */
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+        private int amount;
+    }
+
+    /** 배상 정보 생성 응답 객체 */
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        private Long id;
+    }
+}

--- a/src/test/java/teamfresh/api/web/vocs/compensations/CompensationsCreateControllerMvcTest.java
+++ b/src/test/java/teamfresh/api/web/vocs/compensations/CompensationsCreateControllerMvcTest.java
@@ -1,0 +1,67 @@
+package teamfresh.api.web.vocs.compensations;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.service.CompensationCreator;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CompensationsCreateController.class)
+public class CompensationsCreateControllerMvcTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private CompensationCreator compensationCreator;
+
+    @DisplayName("POST /vocs/{vocId}/compensations")
+    @Nested
+    class Describe_post_compensation {
+
+        Long vocId = 3L;
+        int amount = 28000;
+        Long compensationId = 1L;
+
+        @BeforeEach
+        void setUp() {
+            given(compensationCreator.create(vocId, amount))
+                    .willReturn(Compensation.of(compensationId, amount));
+        }
+
+        @DisplayName("201 Created 상태코드와 함께 등록된 배상 정보의 id를 반환한다")
+        @Test
+        void it_response_compensation_id_with_201_status() throws Exception {
+            CompensationsCreateController.Request request
+                    = new CompensationsCreateController.Request(amount);
+
+           mvc.perform(
+                   post(String.format("/vocs/%s/compensations", vocId))
+                           .contentType(MediaType.APPLICATION_JSON)
+                           .content(toJSON(request))
+           ).andExpectAll(
+                   status().isCreated(),
+                   jsonPath("$.id").isNumber(),
+                   jsonPath("$.id").value(compensationId)
+           );
+        }
+    }
+
+    private String toJSON(Object object) throws JsonProcessingException {
+        ObjectMapper objectMapper = new ObjectMapper();
+        return objectMapper.writeValueAsString(object);
+    }
+}

--- a/src/test/java/teamfresh/api/web/vocs/compensations/CompensationsCreateControllerTest.java
+++ b/src/test/java/teamfresh/api/web/vocs/compensations/CompensationsCreateControllerTest.java
@@ -1,0 +1,78 @@
+package teamfresh.api.web.vocs.compensations;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.service.CompensationCreator;
+import teamfresh.api.application.voc.exception.VocNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CompensationsCreateControllerTest {
+
+    @InjectMocks
+    private CompensationsCreateController compensationsCreateController;
+
+    @Mock
+    private CompensationCreator compensationCreator;
+
+    @DisplayName("handleCompensationCreate 메서드")
+    @Nested
+    class Describe_handle_compensation_create {
+
+        Long vocId = 3L;
+        int amount = 28000;
+        Long compensationId = 1L;
+        CompensationsCreateController.Request request
+                = new CompensationsCreateController.Request(amount);
+
+        @BeforeEach
+        void setUp() {
+            given(compensationCreator.create(vocId, amount))
+                    .willReturn(Compensation.of(compensationId, amount));
+        }
+
+        @DisplayName("배상을 등록할 VOC 건의 id와 배상 금액이 주어지면")
+        @Nested
+        class Context_with_voc_id_and_amount {
+            @DisplayName("등록된 배상 정보의 id를 반환한다")
+            @Test
+            void it_return_compensation_id() {
+                CompensationsCreateController.Response response
+                        = compensationsCreateController.handleCompensationCreate(vocId, request);
+
+                assertThat(response.getId()).isEqualTo(compensationId);
+            }
+        }
+
+        @DisplayName("주어진 vocId에 해당하는 VOC를 찾지 못한 경우")
+        @Nested
+        class Context_with_not_exist_voc_id {
+
+            @BeforeEach
+            void setUp() {
+                given(compensationCreator.create(vocId, amount))
+                        .willThrow(new VocNotFoundException(vocId));
+            }
+
+            @DisplayName("VocNotFoundException을 던진다")
+            @Test
+            void it_throws_voc_not_found_exception() {
+                assertThrows(
+                        VocNotFoundException.class,
+                        () -> compensationsCreateController
+                                .handleCompensationCreate(vocId, request)
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
VOC에 배상을 청구할 경우 배상 정보를 등록할 수 있습니다.
해당하는 VOC 건의 id가 패스 파라미터로, 요청 데이터로 배상 금액이 들어오면
VOC 건에 배상을 접수하고 생성된 배상 정보의 id를 응답합니다.

```
// Request
POST /vocs/{vocId}/compensations
{
    "amount": 20000
}

// Response
201 Created 
{
    "id": 1
}
```
