### PR TITLE
페널티 등록 요청을 처리하는 컨트롤러를 작성하라

### DIFF
--- a/src/main/java/teamfresh/api/web/compensations/penalties/PenaltyIssueController.java
+++ b/src/main/java/teamfresh/api/web/compensations/penalties/PenaltyIssueController.java
@@ -1,0 +1,55 @@
+package teamfresh.api.web.compensations.penalties;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import teamfresh.api.application.penalty.service.PenaltyIssuer;
+
+@RequiredArgsConstructor
+@RequestMapping("/compensations/{compensationId}/penalties")
+@RestController
+public class PenaltyIssueController {
+
+    private final PenaltyIssuer penaltyIssuer;
+
+    /**
+     * 배상 id와 페널티를 발급하기 위한 정보를 받아 페널티를 발급합니다.
+     *
+     * @param compensationId 페널티 배상 정보
+     * @param request 페널티 발급 요청 객체
+     * @return 발급한 페널티의 id
+     */
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public Response handleIssuePenalty(
+            @PathVariable Long compensationId,
+            @RequestBody Request request
+    ) {
+        return new Response(
+                penaltyIssuer.issue(compensationId, request.getOwner()).getId()
+        );
+    }
+
+    /** 페널티 발급 요청 객체 */
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class Request {
+        private Long owner;
+    }
+
+    /** 페널티 발급 응답 객체 */
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        private Long id;
+    }
+}

--- a/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerMvcTest.java
+++ b/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerMvcTest.java
@@ -1,0 +1,66 @@
+package teamfresh.api.web.compensations.penalties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.penalty.domain.Penalty;
+import teamfresh.api.application.penalty.service.PenaltyIssuer;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static teamfresh.api.web.MvcTestHelpers.toJSON;
+
+@WebMvcTest(PenaltyIssueController.class)
+public class PenaltyIssueControllerMvcTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private PenaltyIssuer penaltyIssuer;
+
+    @DisplayName("POST /compensations/{compensationId}/peanlties")
+    @Nested
+    class Describe_post_penalties {
+
+        Long compensationId = 4L;
+        Long ownerId = 11L;
+        Long penaltyId = 8L;
+
+        @DisplayName("배상정보 id와 페널티 대상 id가 주어지면")
+        @Nested
+        class Context_with_compensation_id_and_owner_id {
+            @BeforeEach
+            void setUp() {
+                given(penaltyIssuer.issue(compensationId, ownerId))
+                        .willReturn(Penalty.of(penaltyId, Compensation.of(compensationId, 100000), ownerId));
+            }
+
+            @DisplayName("201 Created 상태코드와 함께 발급된 페널티 id를 응답한다")
+            @Test
+            void it_returns_issued_penalty_id() throws Exception {
+                PenaltyIssueController.Request request
+                        = new PenaltyIssueController.Request(ownerId);
+
+                mvc.perform(
+                        post(String.format("/compensations/%s/penalties", compensationId))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(toJSON(request))
+                ).andExpectAll(
+                        status().isCreated(),
+                        jsonPath("$.id").isNumber(),
+                        jsonPath("$.id").value(penaltyId)
+                );
+            }
+        }
+    }
+}

--- a/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerTest.java
+++ b/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerTest.java
@@ -1,0 +1,85 @@
+package teamfresh.api.web.compensations.penalties;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.exception.CompensationNotFoundException;
+import teamfresh.api.application.penalty.domain.Penalty;
+import teamfresh.api.application.penalty.service.PenaltyIssuer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PenaltyIssueControllerTest {
+
+    @InjectMocks
+    private PenaltyIssueController penaltyIssueController;
+
+    @Mock
+    private PenaltyIssuer penaltyIssuer;
+
+    @DisplayName("handleIssuePenalty 메서드")
+    @Nested
+    class Describe_handle_issue_penalty {
+
+        Long compensationId = 4L;
+        Long ownerId = 11L;
+        Long penaltyId = 8L;
+
+        @DisplayName("배상정보 id와 페널티 대상 id가 주어지면")
+        @Nested
+        class Context_with_compensation_id_and_owner_id {
+            @BeforeEach
+            void setUp() {
+                given(penaltyIssuer.issue(compensationId, ownerId))
+                        .willReturn(Penalty.of(penaltyId, Compensation.of(compensationId, 100000), ownerId));
+            }
+
+            @DisplayName("발급된 페널티 id를 반환한다")
+            @Test
+            void it_returns_issued_penalty_id() {
+                PenaltyIssueController.Request request
+                    = new PenaltyIssueController.Request(ownerId);
+
+                PenaltyIssueController.Response response
+                        = penaltyIssueController.handleIssuePenalty(
+                                compensationId, request
+                );
+
+                assertThat(response.getId()).isEqualTo(penaltyId);
+            }
+        }
+
+        @DisplayName("찾을 수 없는 배상정보 id가 주어지면")
+        @Nested
+        class Context_with_not_exist_compensation_id {
+            @BeforeEach
+            void setUp() {
+                given(penaltyIssuer.issue(compensationId, ownerId))
+                        .willThrow(new CompensationNotFoundException(compensationId));
+            }
+
+            @DisplayName("CompensationNotFoundException을 던진다")
+            @Test
+            void it_throws_compensation_not_found_exception() {
+                PenaltyIssueController.Request request
+                        = new PenaltyIssueController.Request(ownerId);
+
+                assertThrows(CompensationNotFoundException.class,
+                        () -> penaltyIssueController.handleIssuePenalty(
+                                compensationId, request
+                        )
+                );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
배상을 접수 후 해당 건의 귀책이 배송 기사님에게 있을 경우 페널티를 발급합니다.
이 페널티 발급 요청을 처리할 수 있는 컨트롤러를 만들었습니다.

배상건의 id를 패스 파라미터로, 요청 데이터로 페널티 대상 기사님의 id를 받아 처리합니다.

```
// Request
POST /compensations/{compenstaionId}/penalties

{
    "owner": 8,
    "content": "송장번호 2393-1221-1924에 대한 상품 훼손 클레임이 접수되어 페널티가 부과되었습니다."
}

// Response
201 Created
{
    "id": 1
}
```