### PR TITLE
페널티 읽음 처리 API를 만들어라

### DIFF
--- a/src/main/java/teamfresh/api/application/penalty/domain/Penalty.java
+++ b/src/main/java/teamfresh/api/application/penalty/domain/Penalty.java
@@ -53,4 +53,9 @@ public class Penalty {
     public static Penalty of(Compensation compensation, Long owner) {
         return new Penalty(null, compensation, owner, false, false);
     }
+
+    /** 페널티를 확인하면 read 상태를 true로 변경합니다. */
+    public void read() {
+        this.read = Boolean.TRUE;
+    }
 }

--- a/src/main/java/teamfresh/api/application/penalty/service/PenaltyReadUpdater.java
+++ b/src/main/java/teamfresh/api/application/penalty/service/PenaltyReadUpdater.java
@@ -1,0 +1,23 @@
+package teamfresh.api.application.penalty.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamfresh.api.application.penalty.domain.Penalty;
+
+/** 페널티 읽음 처리 담당 */
+@RequiredArgsConstructor
+@Service
+public class PenaltyReadUpdater {
+
+    private final PenaltyReader penaltyReader;
+
+    /**
+     * 페널티 내용을 APP에서 확인하면 페널티의 읽기 여부를 true로 변경합니다.
+     */
+    @Transactional
+    public void update(Long id) {
+        Penalty penalty = penaltyReader.read(id);
+        penalty.read();
+    }
+}

--- a/src/main/java/teamfresh/api/web/penalties/read/PenaltyReadUpdateController.java
+++ b/src/main/java/teamfresh/api/web/penalties/read/PenaltyReadUpdateController.java
@@ -1,0 +1,26 @@
+package teamfresh.api.web.penalties.read;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import teamfresh.api.application.penalty.service.PenaltyReadUpdater;
+
+/** 페널티 읽음 처리 요청 담당 */
+@RequiredArgsConstructor
+@RequestMapping("/penalties/{id}/read")
+@RestController
+public class PenaltyReadUpdateController {
+
+    private final PenaltyReadUpdater readUpdater;
+
+    /** 주어진 페널티 id에 해당하는 페널티 정보를 읽음 처리 합니다. */
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @PatchMapping
+    public void handlePenaltyRead(@PathVariable Long id) {
+        readUpdater.update(id);
+    }
+}

--- a/src/test/java/teamfresh/api/application/penalty/service/PenaltyReadUpdaterIntegrationTest.java
+++ b/src/test/java/teamfresh/api/application/penalty/service/PenaltyReadUpdaterIntegrationTest.java
@@ -1,0 +1,82 @@
+package teamfresh.api.application.penalty.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import teamfresh.api.application.penalty.domain.Penalty;
+import teamfresh.api.application.penalty.domain.PenaltyRepository;
+import teamfresh.api.application.penalty.exception.PenaltyNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+@ExtendWith(MockitoExtension.class)
+@DataJpaTest
+public class PenaltyReadUpdaterIntegrationTest {
+
+    @Autowired
+    private PenaltyRepository repository;
+
+    @SpyBean
+    private PenaltyReader penaltyReader;
+
+    private PenaltyReadUpdater penaltyReadUpdater;
+
+    @BeforeEach
+    void setUp() {
+        this.penaltyReadUpdater = new PenaltyReadUpdater(penaltyReader);
+    }
+
+    @DisplayName("update 메서드")
+    @Nested
+    class Describe_update {
+
+        Long penaltyId;
+
+        @BeforeEach
+        void setUp() {
+            penaltyId =
+                    repository.save(
+                            Penalty.of(null, 2L)
+                    ).getId();
+        }
+
+        @DisplayName("찾을 수 있는 페널티 id가 주어지면")
+        @Nested
+        class Context_with_exist_id {
+            @DisplayName("read 상태를 true로 갱신한다")
+            @Test
+            void it_update_read_true() {
+                penaltyReadUpdater.update(penaltyId);
+
+                assertThat(
+                        repository.findById(penaltyId).get().getRead()
+                ).isTrue();
+            }
+        }
+
+        @DisplayName("찾을 수 없는 페널티 id가 주어지면")
+        @Nested
+        class Context_with_not_exist_id {
+            @BeforeEach
+            void setUp() {
+                if(repository.findById(penaltyId).isPresent()) {
+                    repository.deleteById(penaltyId);
+                }
+            }
+
+            @DisplayName("PenaltyNotFoundException을 던진다")
+            @Test
+            void it_throws_penalty_not_found_exception() {
+                assertThrows(PenaltyNotFoundException.class,
+                        () -> penaltyReadUpdater.update(penaltyId));
+            }
+        }
+    }
+}

--- a/src/test/java/teamfresh/api/application/penalty/service/PenaltyReadUpdaterTest.java
+++ b/src/test/java/teamfresh/api/application/penalty/service/PenaltyReadUpdaterTest.java
@@ -1,0 +1,72 @@
+package teamfresh.api.application.penalty.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.penalty.domain.Penalty;
+import teamfresh.api.application.penalty.exception.PenaltyNotFoundException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PenaltyReadUpdaterTest {
+
+    @InjectMocks
+    private PenaltyReadUpdater penaltyReadUpdater;
+
+    @Mock
+    private PenaltyReader penaltyReader;
+
+    @DisplayName("update 메서드")
+    @Nested
+    class Describe_update {
+
+        Long id = 1L;
+
+        @DisplayName("찾을 수 있는 페널티 id가 주어지면")
+        @Nested
+        class Context_with_exist_if {
+
+            Penalty penalty = Penalty.of(id, null, 2L);
+
+            @BeforeEach
+            void setUp() {
+                given(penaltyReader.read(id))
+                        .willReturn(penalty);
+            }
+
+            @DisplayName("read 상태를 true로 갱신한다")
+            @Test
+            void it_change_read_to_true() {
+                penaltyReadUpdater.update(id);
+
+                assertThat(penalty.getRead()).isTrue();
+            }
+        }
+
+        @DisplayName("찾을 수 없는 페널티 id가 주어지면")
+        @Nested
+        class Context_with_not_exist_id {
+            @BeforeEach
+            void setUp() {
+                given(penaltyReader.read(id))
+                        .willThrow(new PenaltyNotFoundException(id));
+            }
+
+            @DisplayName("PenaltyNotFoundException을 던진다")
+            @Test
+            void it_throws_penalty_not_found_exception() {
+                assertThrows(PenaltyNotFoundException.class,
+                        () -> penaltyReadUpdater.update(id));
+            }
+        }
+    }
+
+}

--- a/src/test/java/teamfresh/api/web/penalties/read/PenaltyReadUpdateControllerMvcTest.java
+++ b/src/test/java/teamfresh/api/web/penalties/read/PenaltyReadUpdateControllerMvcTest.java
@@ -1,0 +1,40 @@
+package teamfresh.api.web.penalties.read;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import teamfresh.api.application.penalty.service.PenaltyReadUpdater;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PenaltyReadUpdateController.class)
+public class PenaltyReadUpdateControllerMvcTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private PenaltyReadUpdater penaltyReadUpdater;
+
+    @DisplayName("PATCH /penalties/{id}/read")
+    @Nested
+    class Describe_handle_read_penalty {
+
+        Long id = 1L;
+
+        @DisplayName("204 No Content를 응답한다")
+        @Test
+        void it_update_read_true() throws Exception {
+            mvc.perform(
+                    patch(String.format("/penalties/%s/read", id))
+            ).andExpectAll(
+                    status().isNoContent()
+            );
+        }
+    }
+}

--- a/src/test/java/teamfresh/api/web/penalties/read/PenaltyReadUpdateControllerTest.java
+++ b/src/test/java/teamfresh/api/web/penalties/read/PenaltyReadUpdateControllerTest.java
@@ -1,0 +1,62 @@
+package teamfresh.api.web.penalties.read;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.penalty.exception.PenaltyNotFoundException;
+import teamfresh.api.application.penalty.service.PenaltyReadUpdater;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PenaltyReadUpdateControllerTest {
+
+    @InjectMocks
+    private PenaltyReadUpdateController controller;
+
+    @Mock
+    private PenaltyReadUpdater penaltyReadUpdater;
+
+    @DisplayName("handleReadPenalty 메서드")
+    @Nested
+    class Describe_handle_read_penalty {
+
+        Long penaltyId = 1L;
+
+        @DisplayName("찾을 수 있는 페널티 id가 주어지면")
+        @Nested
+        class Context_with_exist_penalty_id {
+            @DisplayName("페널티를 읽음 처리 한다")
+            @Test
+            void it_change_read_to_true() {
+                controller.handlePenaltyRead(penaltyId);
+
+                verify(penaltyReadUpdater, times(1))
+                        .update(penaltyId);
+            }
+        }
+
+        @DisplayName("주어진 페널티 id에 해당하는 페널티를 찾을 수 없으면")
+        @Nested
+        class Context_with_not_exist_penalty_id {
+            @BeforeEach
+            void setUp() {
+                doThrow(new PenaltyNotFoundException(penaltyId))
+                        .when(penaltyReadUpdater).update(penaltyId);
+            }
+
+            @DisplayName("PenaltyNotFoundException을 던진다")
+            @Test
+            void it_throws_penalty_not_found_exception() {
+                assertThrows(PenaltyNotFoundException.class,
+                        () -> controller.handlePenaltyRead(penaltyId));
+            }
+        }
+    }
+}


### PR DESCRIPTION
기사님이 APP에서 발급된 페널티 정보를 확인하면 페널티 확인 여부가 true로 변경되어야 합니다.
따라서 해당 요청을 처리할 수 있는 컨트롤러와 서비스를 만들었습니다.

```
// Request
PATCH /penalties/{id}/read

// Response
204 No Content
```