### PR TITLE
VOC 목록 조회 API를 만들어라

### DIFF
--- a/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
@@ -1,10 +1,13 @@
 package teamfresh.api.application.compensation.domain;
 
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.OneToOne;
 import lombok.Getter;
+import teamfresh.api.application.penalty.domain.Penalty;
 
 /** 배상정보 엔티티 */
 @Getter
@@ -17,19 +20,23 @@ public class Compensation {
 
     private int amount;
 
+    @OneToOne(mappedBy = "compensation", fetch = FetchType.LAZY)
+    private Penalty penalty;
+
     protected Compensation() {
     }
 
-    private Compensation(final Long id, final int amount) {
+    public Compensation(final Long id, final int amount, final Penalty penalty) {
         this.id = id;
         this.amount = amount;
+        this.penalty = penalty;
     }
 
     public static Compensation of(Long id, int amount) {
-        return new Compensation(id, amount);
+        return new Compensation(id, amount, null);
     }
 
     public static Compensation of(int amount) {
-        return new Compensation(null, amount);
+        return new Compensation(null, amount, null);
     }
 }

--- a/src/main/java/teamfresh/api/application/voc/domain/Voc.java
+++ b/src/main/java/teamfresh/api/application/voc/domain/Voc.java
@@ -65,6 +65,10 @@ public class Voc {
         return new Voc(id, content, blame, null, customerManagerId, createdBy);
     }
 
+    public static Voc of(Long id, String content, Blame blame, Compensation compensation, Long customerManagerId, Long createdBy) {
+        return new Voc(id, content, blame, compensation, customerManagerId, createdBy);
+    }
+
     /**
      * 해당 VOC 건에 대한 배상을 접수합니다.
      */

--- a/src/main/java/teamfresh/api/application/voc/domain/VocRepository.java
+++ b/src/main/java/teamfresh/api/application/voc/domain/VocRepository.java
@@ -1,7 +1,19 @@
 package teamfresh.api.application.voc.domain;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
 
 /** VOC 리포지토리 */
 public interface VocRepository extends CrudRepository<Voc, Long> {
+
+    /** VOC 목록을 fetch join을 사용하여 모두 조회합니다. */
+    @Query(
+            "select v from Voc v " +
+                    "left join fetch v.blame " +
+                    "left join fetch v.compensation " +
+                    "left join fetch v.compensation.penalty"
+    )
+    List<Voc> findAllWithFetch();
 }

--- a/src/main/java/teamfresh/api/application/voc/service/VocListReader.java
+++ b/src/main/java/teamfresh/api/application/voc/service/VocListReader.java
@@ -1,0 +1,23 @@
+package teamfresh.api.application.voc.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.domain.VocRepository;
+
+import java.util.List;
+
+/** VOC 목록 조회 담당 */
+@RequiredArgsConstructor
+@Service
+public class VocListReader {
+
+    private final VocRepository repository;
+
+    /** VOC 목록을 모두 조회합니다. */
+    @Transactional(readOnly = true)
+    public List<Voc> read() {
+        return repository.findAllWithFetch();
+    }
+}

--- a/src/main/java/teamfresh/api/web/vocs/VocListController.java
+++ b/src/main/java/teamfresh/api/web/vocs/VocListController.java
@@ -1,0 +1,105 @@
+package teamfresh.api.web.vocs;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.penalty.domain.Penalty;
+import teamfresh.api.application.voc.blame.domain.Blame;
+import teamfresh.api.application.voc.blame.domain.BlameTarget;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.service.VocListReader;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** VOC 목록 조회 요청 담당 */
+@RequiredArgsConstructor
+@RequestMapping("/vocs")
+@RestController
+public class VocListController {
+
+    private final VocListReader vocListReader;
+
+    /** VOC 목록을 모두 조회 후 응답합니다. */
+    @GetMapping
+    public Response handleReadVocList() {
+        return new Response(
+                vocListReader.read()
+                        .stream()
+                        .map(Response.VocDto::new)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    /** VOC 목록 응답 객체 */
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+
+        private List<VocDto> vocs;
+
+        @Getter
+        public static class VocDto {
+            private Long id;
+            private String content;
+            private BlameDto blame;
+            private CompensationDto compensation;
+            private PenaltyDto penalty;
+
+            public VocDto(Voc voc) {
+                this.id = voc.getId();
+                this.content = voc.getContent();
+                this.blame = new BlameDto(voc.getBlame());
+                this.compensation = new CompensationDto(voc.getCompensation());
+                this.penalty = new PenaltyDto(voc.getCompensation().getPenalty());
+            }
+
+            @Getter
+            public static class BlameDto {
+                private Long id;
+                private BlameTarget target;
+                private String cause;
+
+                public BlameDto(Blame blame) {
+                    if (blame != null) {
+                        this.id = blame.getId();
+                        this.target = blame.getTarget();
+                        this.cause = blame.getCause();
+                    }
+                }
+            }
+
+            @Getter
+            public static class CompensationDto {
+                private Long id;
+                private int amount;
+
+                public CompensationDto(Compensation compensation) {
+                    if (compensation != null) {
+                        this.id = compensation.getId();
+                        this.amount = compensation.getAmount();
+                    }
+                }
+            }
+
+            @Getter
+            public static class PenaltyDto {
+                private Long id;
+                private Boolean read;
+                private Boolean confirmed;
+
+                public PenaltyDto(Penalty penalty) {
+                    if (penalty != null) {
+                        this.id = penalty.getId();
+                        this.read = penalty.getRead();
+                        this.confirmed = penalty.getConfirmed();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/teamfresh/api/application/voc/service/VocListReaderTest.java
+++ b/src/test/java/teamfresh/api/application/voc/service/VocListReaderTest.java
@@ -1,0 +1,73 @@
+package teamfresh.api.application.voc.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.voc.blame.domain.Blame;
+import teamfresh.api.application.voc.blame.domain.BlameTarget;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.domain.VocRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class VocListReaderTest {
+
+    @InjectMocks
+    private VocListReader vocListReader;
+
+    @Mock
+    private VocRepository repository;
+
+    @DisplayName("read 메서드")
+    @Nested
+    class Describe_read {
+
+        @BeforeEach
+        void setUp() {
+            given(repository.findAllWithFetch())
+                    .willReturn(createVodList());
+        }
+
+        @DisplayName("모든 VOC 목록을 조회 후 반환한다")
+        @Test
+        void it_returns_all_vocs() {
+            List<Voc> vocList = vocListReader.read();
+
+            verify(repository, times(1)).findAllWithFetch();
+            assertThat(vocList).isNotEmpty();
+        }
+    }
+
+    private List<Voc> createVodList() {
+        return List.of(
+                Voc.of(
+                        1L,
+                        "voc content 1",
+                        Blame.of(1L, BlameTarget.CARRIER, "blaem cause 1"),
+                        Compensation.of(1L, 10000),
+                        8L,
+                        99L
+                ),
+                Voc.of(
+                        2L,
+                        "voc content 2",
+                        Blame.of(2L, BlameTarget.CARRIER, "blaem cause 2"),
+                        Compensation.of(2L, 10000),
+                        4L,
+                        99L
+                )
+        );
+    }
+}

--- a/src/test/java/teamfresh/api/web/vocs/VocListControllerMvcTest.java
+++ b/src/test/java/teamfresh/api/web/vocs/VocListControllerMvcTest.java
@@ -1,0 +1,71 @@
+package teamfresh.api.web.vocs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.voc.blame.domain.Blame;
+import teamfresh.api.application.voc.blame.domain.BlameTarget;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.service.VocListReader;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(VocListController.class)
+public class VocListControllerMvcTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private VocListReader vocListReader;
+
+    @DisplayName("GET /vocs")
+    @Nested
+    class Describe_handle_read_voc_list {
+
+        @BeforeEach
+        void setUp() {
+            given(vocListReader.read())
+                    .willReturn(createVodList());
+        }
+
+        @DisplayName("200 Ok 상태코드와 함게 VOD 목록을 반환한다")
+        @Test
+        void it_response_vocs_with_200_status() throws Exception {
+            mvc.perform(
+                    get("/vocs")
+            ).andDo(print()).andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.vocs").isArray(),
+                    jsonPath("$.vocs[0].blame").exists(),
+                    jsonPath("$.vocs[0].compensation").exists(),
+                    jsonPath("$.vocs[0].penalty").exists()
+            );
+        }
+    }
+
+    private List<Voc> createVodList() {
+        return List.of(
+                Voc.of(
+                        1L,
+                        "voc content 1",
+                        Blame.of(1L, BlameTarget.CARRIER, "blaem cause 1"),
+                        Compensation.of(1L, 10000),
+                        8L,
+                        99L
+                )
+        );
+    }
+}

--- a/src/test/java/teamfresh/api/web/vocs/VocListControllerTest.java
+++ b/src/test/java/teamfresh/api/web/vocs/VocListControllerTest.java
@@ -1,0 +1,64 @@
+package teamfresh.api.web.vocs;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.voc.blame.domain.Blame;
+import teamfresh.api.application.voc.blame.domain.BlameTarget;
+import teamfresh.api.application.voc.domain.Voc;
+import teamfresh.api.application.voc.service.VocListReader;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class VocListControllerTest {
+
+    @InjectMocks
+    private VocListController vocListController;
+
+    @Mock
+    private VocListReader vocListReader;
+
+    @DisplayName("handleReadVocList 메서드")
+    @Nested
+    class Describe_handle_read_voc_list {
+
+        @BeforeEach
+        void setUp() {
+            given(vocListReader.read())
+                    .willReturn(createVodList());
+        }
+
+        @DisplayName("VOC 목록읇 반환한다")
+        @Test
+        void it_returns_voc_list() {
+            VocListController.Response response = vocListController.handleReadVocList();
+
+            assertThat(response.getVocs()).isInstanceOf(List.class);
+            assertThat(response.getVocs().get(0))
+                    .isInstanceOf(VocListController.Response.VocDto.class);
+        }
+    }
+
+    private List<Voc> createVodList() {
+        return List.of(
+                Voc.of(
+                        1L,
+                        "voc content 1",
+                        Blame.of(1L, BlameTarget.CARRIER, "blaem cause 1"),
+                        Compensation.of(1L, 10000),
+                        8L,
+                        99L
+                )
+        );
+    }
+}


### PR DESCRIPTION
VOC 목록 조회 API를 추가합니다.
사용 방법은 아래 코드블록과 테스트 코드를 참고하시기 바랍니다.

```
// Request
GET /vocs

// Response
200 OK
{
	"vocs": [
		{
			"id": 1,
			"content": "배송 받은 물건이 파손되어있다고 클레임이 들어옴",
			"blame": {
				"id": 1,
				"target": "CARRIER",
				"cause": "배송 기사님 실수로 인한 박스 훼손으로 인한 파손",
			},
			"compensation": {
				"id": 1,
				"amount": 100000,
				"status": "PROCEED",
			},
			"penalty": {
				"id": 1,
				"read": false,
				"confirmed": false,
			}
		},
		{
			"id": 2,
			"content": "오배송으로 인한 배송지연 및 주문취소 발생",
			"blame": {
				"id": 1,
				"target": "CARRIER",
				"cause": "오배송",
			},
			"compensation": {},
			"penalty": {
				"id": 6,
				"read": true,
				"confirmed": false,
			}
		},
		{ ... }
	]
}
```