### PR TITLE
배상목록 조회 API를 만들어라

### DIFF
--- a/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import teamfresh.api.application.penalty.domain.Penalty;
+import teamfresh.api.application.voc.domain.Voc;
 
 /** 배상정보 엔티티 */
 @Getter
@@ -21,22 +22,33 @@ public class Compensation {
     private int amount;
 
     @OneToOne(mappedBy = "compensation", fetch = FetchType.LAZY)
+    private Voc voc;
+
+    @OneToOne(mappedBy = "compensation", fetch = FetchType.LAZY)
     private Penalty penalty;
 
     protected Compensation() {
     }
 
-    public Compensation(final Long id, final int amount, final Penalty penalty) {
+    private Compensation(final Long id, final int amount, final Voc voc, final Penalty penalty) {
         this.id = id;
         this.amount = amount;
         this.penalty = penalty;
     }
 
-    public static Compensation of(Long id, int amount) {
-        return new Compensation(id, amount, null);
+    public static Compensation of(int amount) {
+        return new Compensation(null, amount, null, null);
     }
 
-    public static Compensation of(int amount) {
-        return new Compensation(null, amount, null);
+    public static Compensation of(Long id, int amount) {
+        return new Compensation(id, amount, null, null);
+    }
+
+    public static Compensation of(int amount, Voc voc, Penalty penalty) {
+        return new Compensation(null, amount, voc, penalty);
+    }
+
+    public static Compensation of(Long id, int amount, Voc voc, Penalty penalty) {
+        return new Compensation(id, amount, voc, penalty);
     }
 }

--- a/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
@@ -1,6 +1,15 @@
 package teamfresh.api.application.compensation.domain;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 
+import java.util.List;
+
 public interface CompensationRepository extends CrudRepository<Compensation, Long> {
+
+    @Query(
+            "select c from Compensation c" +
+                    "join c.compensation"
+    )
+    List<Compensation> findAllWithFetch();
 }

--- a/src/main/java/teamfresh/api/application/compensation/service/CompensationListReader.java
+++ b/src/main/java/teamfresh/api/application/compensation/service/CompensationListReader.java
@@ -1,0 +1,23 @@
+package teamfresh.api.application.compensation.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.domain.CompensationRepository;
+
+import java.util.List;
+
+/** 배상 목록 조회 담당 */
+@RequiredArgsConstructor
+@Service
+public class CompensationListReader {
+
+    private final CompensationRepository repository;
+
+    /** 배상 목록을 조회 후 반환합니다. */
+    @Transactional(readOnly = true)
+    public List<Compensation> read() {
+        return repository.findAllWithFetch();
+    }
+}

--- a/src/main/java/teamfresh/api/web/compensations/CompensationListController.java
+++ b/src/main/java/teamfresh/api/web/compensations/CompensationListController.java
@@ -1,0 +1,67 @@
+package teamfresh.api.web.compensations;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.service.CompensationListReader;
+import teamfresh.api.application.voc.domain.Voc;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** 배상 목록 조회 요청 담당 */
+@RequiredArgsConstructor
+@RequestMapping("/compensations")
+@RestController
+public class CompensationListController {
+
+    private final CompensationListReader compensationListReader;
+
+    /** 배상 목록을 응답합니다. */
+    @GetMapping
+    public Response handleReadCompensationList() {
+        return new Response(
+                compensationListReader.read()
+                        .stream()
+                        .map(Response.CompensationDto::new)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    /** 배상 목록 응답 객체*/
+    @Getter
+    @AllArgsConstructor
+    public static class Response {
+        private List<CompensationDto> compensations;
+
+        @Getter
+        public static class CompensationDto {
+            private Long id;
+            private int amount;
+            private VocDto voc;
+
+            public CompensationDto(Compensation compensation) {
+                this.id = compensation.getId();
+                this.amount = compensation.getAmount();
+                this.voc = new VocDto(compensation.getVoc());
+            }
+
+            @Getter
+            public static class VocDto {
+                private Long id;
+                private String content;
+
+                public VocDto(Voc voc) {
+                    if (voc != null) {
+                        this.id = voc.getId();
+                        this.content = voc.getContent();
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/test/java/teamfresh/api/application/compensation/service/CompensationListReaderTest.java
+++ b/src/test/java/teamfresh/api/application/compensation/service/CompensationListReaderTest.java
@@ -1,0 +1,58 @@
+package teamfresh.api.application.compensation.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.domain.CompensationRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class CompensationListReaderTest {
+
+    @InjectMocks
+    private CompensationListReader compensationListReader;
+
+    @Mock
+    private CompensationRepository repository;
+
+    @DisplayName("read 메서드")
+    @Nested
+    class Describe_read {
+
+        @BeforeEach
+        void setUp() {
+            given(repository.findAllWithFetch())
+                    .willReturn(createCompensationList());
+        }
+
+        @DisplayName("배상목록을 조회 후 반환한다")
+        @Test
+        void it_returns_compensation_list() {
+            List<Compensation> compensationList = compensationListReader.read();
+
+            verify(repository, times(1)).findAllWithFetch();
+            assertThat(compensationList).isNotEmpty();
+        }
+    }
+
+    private List<Compensation> createCompensationList() {
+        return List.of(
+                Compensation.of(1L, 10000),
+                Compensation.of(2L, 11000),
+                Compensation.of(3L, 30000),
+                Compensation.of(4L, 1000)
+        );
+    }
+}

--- a/src/test/java/teamfresh/api/web/compensations/CompensationListControllerMvcTest.java
+++ b/src/test/java/teamfresh/api/web/compensations/CompensationListControllerMvcTest.java
@@ -1,0 +1,63 @@
+package teamfresh.api.web.compensations;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.service.CompensationListReader;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CompensationListController.class)
+public class CompensationListControllerMvcTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @MockBean
+    private CompensationListReader compensationListReader;
+
+    @DisplayName("GET /compensations")
+    @Nested
+    class Describe_handle_read_compensation_list {
+
+        List<Compensation> compensationList = createCompensationList();
+
+        @BeforeEach
+        void setUp() {
+            given(compensationListReader.read())
+                    .willReturn(compensationList);
+        }
+
+        @DisplayName("배상 목록을 200 Ok 상태코드와 함께 반환한다")
+        @Test
+        void it_response_compensation_list_with_200_status() throws Exception {
+            mvc.perform(
+                    get("/compensations")
+            ).andExpectAll(
+                    status().isOk(),
+                    jsonPath("$.compensations").isArray(),
+                    jsonPath("$.compensations[0].voc").exists()
+            );
+        }
+    }
+
+    private List<Compensation> createCompensationList() {
+        return List.of(
+                Compensation.of(1L, 10000),
+                Compensation.of(2L, 11000),
+                Compensation.of(3L, 30000),
+                Compensation.of(4L, 1000)
+        );
+    }
+}

--- a/src/test/java/teamfresh/api/web/compensations/CompensationListControllerTest.java
+++ b/src/test/java/teamfresh/api/web/compensations/CompensationListControllerTest.java
@@ -1,0 +1,58 @@
+package teamfresh.api.web.compensations;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.compensation.service.CompensationListReader;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CompensationListControllerTest {
+
+    @InjectMocks
+    private CompensationListController compensationListController;
+
+    @Mock
+    private CompensationListReader compensationListReader;
+
+    @DisplayName("handleReadCompensationList 메서드")
+    @Nested
+    class Describe_handle_read_compensation_list {
+
+        List<Compensation> compensationList = createCompensationList();
+
+        @BeforeEach
+        void setUp() {
+            given(compensationListReader.read())
+                    .willReturn(compensationList);
+        }
+
+        @DisplayName("배상 목록을 반환한다")
+        @Test
+        void it_returns_compensation_list() {
+            CompensationListController.Response response
+                    = compensationListController.handleReadCompensationList();
+
+            assertThat(compensationList.size()).isEqualTo(response.getCompensations().size());
+        }
+    }
+
+    private List<Compensation> createCompensationList() {
+        return List.of(
+                Compensation.of(1L, 10000),
+                Compensation.of(2L, 11000),
+                Compensation.of(3L, 30000),
+                Compensation.of(4L, 1000)
+        );
+    }
+}


### PR DESCRIPTION
배상 목록을 조회할 수 있는 서비스와 컨트롤러를 만들었습니다.
배상 목록 조회 시 VOC 정보가 포함되어야 하므로 VOC와의 연관관계를 양방향으로 변경했습니다.

```
// Request
GET /compensations

// Response
200 OK
{
	"compensations": [
		{
			"id": 1,
			"voc": {
				"id": 1,
				"content": "voc content"
			},
			"amount": 100000,
		},
		{ ... }
	]
}
```