### PR TITLE
잘못된 쿼리를 변경하라

### DIFF
--- a/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
@@ -8,8 +8,8 @@ import java.util.List;
 public interface CompensationRepository extends CrudRepository<Compensation, Long> {
 
     @Query(
-            "select c from Compensation c" +
-                    "join c.compensation"
+            "select c from Compensation c " +
+                    "join fetch c.penalty"
     )
     List<Compensation> findAllWithFetch();
 }


### PR DESCRIPTION
잘못된 쿼리를 작성하여 리포지토리가 올바르게 생성되지 않는 문제를 고쳤습니다.