### PR TITLE
페널티 내용과 함께 페널티를 발급하라

### DIFF
--- a/src/main/java/teamfresh/api/application/penalty/domain/Penalty.java
+++ b/src/main/java/teamfresh/api/application/penalty/domain/Penalty.java
@@ -27,6 +27,9 @@ public class Penalty {
     /** 페널티 소유자 */
     private Long owner;
 
+    /** 페널티 내용 */
+    private String content;
+
     /** 페널티 확인 여부 */
     @Column(name = "is_read", columnDefinition = "tinyint")
     private Boolean read;
@@ -38,20 +41,29 @@ public class Penalty {
     protected Penalty() {
     }
 
-    private Penalty(final Long id, final Compensation compensation, final Long owner, final Boolean read, final Boolean confirmed) {
+    private Penalty(final Long id, final Compensation compensation, final Long owner, final String content, final Boolean read, final Boolean confirmed) {
         this.id = id;
         this.compensation = compensation;
         this.owner = owner;
+        this.content = content;
         this.read = read;
         this.confirmed = confirmed;
     }
 
-    public static Penalty of(Long id, Compensation compensation, Long owner) {
-        return new Penalty(id, compensation, owner, false, false);
+    public static Penalty of(Compensation compensation, Long owner) {
+        return new Penalty(null, compensation, owner, null, false, false);
     }
 
-    public static Penalty of(Compensation compensation, Long owner) {
-        return new Penalty(null, compensation, owner, false, false);
+    public static Penalty of(Compensation compensation, Long owner, String content) {
+        return new Penalty(null, compensation, owner, content, false, false);
+    }
+
+    public static Penalty of(Long id, Compensation compensation, Long owner) {
+        return new Penalty(id, compensation, owner, null, false, false);
+    }
+
+    public static Penalty of(Long id, Compensation compensation, Long owner, String content) {
+        return new Penalty(id, compensation, owner, content, false, false);
     }
 
     /** 페널티를 확인하면 read 상태를 true로 변경합니다. */

--- a/src/main/java/teamfresh/api/application/penalty/service/PenaltyIssuer.java
+++ b/src/main/java/teamfresh/api/application/penalty/service/PenaltyIssuer.java
@@ -21,13 +21,14 @@ public class PenaltyIssuer {
      *
      * @param compensationId 배상 정보 id
      * @param owner 페널티 대상
+     * @param content 페널티 내용
      * @return 등록된 페널티 정보
      */
     @Transactional
-    public Penalty issue(Long compensationId, Long owner) {
+    public Penalty issue(Long compensationId, Long owner, String content) {
         Compensation compensation = compensationReader.read(compensationId);
         return repository.save(
-                Penalty.of(compensation, owner)
+                Penalty.of(compensation, owner, content)
         );
     }
 }

--- a/src/main/java/teamfresh/api/web/compensations/penalties/PenaltyIssueController.java
+++ b/src/main/java/teamfresh/api/web/compensations/penalties/PenaltyIssueController.java
@@ -34,7 +34,11 @@ public class PenaltyIssueController {
             @RequestBody Request request
     ) {
         return new Response(
-                penaltyIssuer.issue(compensationId, request.getOwner()).getId()
+                penaltyIssuer.issue(
+                        compensationId,
+                        request.getOwner(),
+                        request.getContent()
+                ).getId()
         );
     }
 
@@ -44,6 +48,7 @@ public class PenaltyIssueController {
     @NoArgsConstructor
     public static class Request {
         private Long owner;
+        private String content;
     }
 
     /** 페널티 발급 응답 객체 */

--- a/src/test/java/teamfresh/api/application/penalty/service/PenaltyIssuerIntegrationTest.java
+++ b/src/test/java/teamfresh/api/application/penalty/service/PenaltyIssuerIntegrationTest.java
@@ -45,6 +45,7 @@ public class PenaltyIssuerIntegrationTest {
 
         Long compensationId;
         Long owner = 8L;
+        String content = "페널티 내용";
 
         @BeforeEach
         void setUp() {
@@ -56,7 +57,7 @@ public class PenaltyIssuerIntegrationTest {
         @DisplayName("페널티 정보가 배상정보 id와 함께 저장된다")
         @Test
         void it_will_save_penalty() {
-            Penalty penalty = penaltyIssuer.issue(compensationId, owner);
+            Penalty penalty = penaltyIssuer.issue(compensationId, owner, content);
 
             assertThat(penalty).isNotNull();
             assertThat(penalty.getCompensation().getId()).isEqualTo(compensationId);
@@ -81,7 +82,7 @@ public class PenaltyIssuerIntegrationTest {
             @Test
             void it_throws_compensation_not_found_exception() {
                 assertThrows(CompensationNotFoundException.class,
-                        () -> penaltyIssuer.issue(compensationId, owner));
+                        () -> penaltyIssuer.issue(compensationId, owner, content));
             }
         }
     }

--- a/src/test/java/teamfresh/api/application/penalty/service/PenaltyIssuerTest.java
+++ b/src/test/java/teamfresh/api/application/penalty/service/PenaltyIssuerTest.java
@@ -38,7 +38,7 @@ class PenaltyIssuerTest {
         Long compensationId = 1L;
         Compensation compensation = Compensation.of(compensationId, 32000);
         Long owner = 17L;
-
+        String content = "페널티 내용";
 
         @DisplayName("배상정보 id와 페널티 대상 id가 주어지면")
         @Nested
@@ -49,13 +49,13 @@ class PenaltyIssuerTest {
                 given(compensationReader.read(compensationId))
                         .willReturn(compensation);
                 given(repository.save(any()))
-                        .willReturn(Penalty.of(1L, compensation, owner));
+                        .willReturn(Penalty.of(1L, compensation, owner, content));
             }
 
             @DisplayName("페널티를 생성 후 반환한다")
             @Test
             void it_returns_penalty() {
-                Penalty penalty = penaltyIssuer.issue(compensationId, owner);
+                Penalty penalty = penaltyIssuer.issue(compensationId, owner, content);
 
                 assertThat(penalty).isNotNull();
                 assertThat(penalty.getCompensation().getId()).isEqualTo(compensationId);
@@ -76,7 +76,7 @@ class PenaltyIssuerTest {
             @Test
             void it_throws_compensation_not_found_exception() {
                 assertThrows(CompensationNotFoundException.class,
-                        () -> penaltyIssuer.issue(compensationId, owner));
+                        () -> penaltyIssuer.issue(compensationId, owner, content));
             }
         }
     }

--- a/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerMvcTest.java
+++ b/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerMvcTest.java
@@ -35,13 +35,14 @@ public class PenaltyIssueControllerMvcTest {
         Long compensationId = 4L;
         Long ownerId = 11L;
         Long penaltyId = 8L;
+        String content = "페널티 내용";
 
         @DisplayName("배상정보 id와 페널티 대상 id가 주어지면")
         @Nested
         class Context_with_compensation_id_and_owner_id {
             @BeforeEach
             void setUp() {
-                given(penaltyIssuer.issue(compensationId, ownerId))
+                given(penaltyIssuer.issue(compensationId, ownerId, content))
                         .willReturn(Penalty.of(penaltyId, Compensation.of(compensationId, 100000), ownerId));
             }
 
@@ -49,7 +50,7 @@ public class PenaltyIssueControllerMvcTest {
             @Test
             void it_returns_issued_penalty_id() throws Exception {
                 PenaltyIssueController.Request request
-                        = new PenaltyIssueController.Request(ownerId);
+                        = new PenaltyIssueController.Request(ownerId, content);
 
                 mvc.perform(
                         post(String.format("/compensations/%s/penalties", compensationId))

--- a/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerTest.java
+++ b/src/test/java/teamfresh/api/web/compensations/penalties/PenaltyIssueControllerTest.java
@@ -33,21 +33,29 @@ class PenaltyIssueControllerTest {
         Long compensationId = 4L;
         Long ownerId = 11L;
         Long penaltyId = 8L;
+        String content = "페널티 내용";
 
         @DisplayName("배상정보 id와 페널티 대상 id가 주어지면")
         @Nested
         class Context_with_compensation_id_and_owner_id {
             @BeforeEach
             void setUp() {
-                given(penaltyIssuer.issue(compensationId, ownerId))
-                        .willReturn(Penalty.of(penaltyId, Compensation.of(compensationId, 100000), ownerId));
+                given(penaltyIssuer.issue(compensationId, ownerId, content))
+                        .willReturn(
+                                Penalty.of(
+                                        penaltyId,
+                                        Compensation.of(compensationId, 100000),
+                                        ownerId,
+                                        content
+                                )
+                        );
             }
 
             @DisplayName("발급된 페널티 id를 반환한다")
             @Test
             void it_returns_issued_penalty_id() {
                 PenaltyIssueController.Request request
-                    = new PenaltyIssueController.Request(ownerId);
+                    = new PenaltyIssueController.Request(ownerId, content);
 
                 PenaltyIssueController.Response response
                         = penaltyIssueController.handleIssuePenalty(
@@ -63,7 +71,7 @@ class PenaltyIssueControllerTest {
         class Context_with_not_exist_compensation_id {
             @BeforeEach
             void setUp() {
-                given(penaltyIssuer.issue(compensationId, ownerId))
+                given(penaltyIssuer.issue(compensationId, ownerId, content))
                         .willThrow(new CompensationNotFoundException(compensationId));
             }
 
@@ -71,7 +79,7 @@ class PenaltyIssueControllerTest {
             @Test
             void it_throws_compensation_not_found_exception() {
                 PenaltyIssueController.Request request
-                        = new PenaltyIssueController.Request(ownerId);
+                        = new PenaltyIssueController.Request(ownerId, content);
 
                 assertThrows(CompensationNotFoundException.class,
                         () -> penaltyIssueController.handleIssuePenalty(


### PR DESCRIPTION
기존 페널티 엔티티에는 페널티 내용 속성이 존재하지 않았기 때문에 페널티 내용을 등록할 수 없었습니다.
페널티를 발급할 때 페널티에 대한 내용을 작성할 수 있도록 `content` 속성을 추가합니다.