### PR TITLE
회사와 회사 소속 직원을 관리하는 엔티티를 추가하라

### DIFF
--- a/src/main/java/teamfresh/api/application/company/domain/Company.java
+++ b/src/main/java/teamfresh/api/application/company/domain/Company.java
@@ -1,0 +1,36 @@
+package teamfresh.api.application.company.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+
+/** 회사 엔티티 */
+@Getter
+@Entity
+public class Company {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(length = 120)
+    private String name;
+
+    @Column(length = 20)
+    private String phone;
+
+    private String address;
+
+    protected Company() {
+    }
+
+    public Company(final Long id, final String name, final String phone, final String address) {
+        this.id = id;
+        this.name = name;
+        this.phone = phone;
+        this.address = address;
+    }
+}

--- a/src/main/java/teamfresh/api/application/company/employee/CustomerManager.java
+++ b/src/main/java/teamfresh/api/application/company/employee/CustomerManager.java
@@ -1,0 +1,58 @@
+package teamfresh.api.application.company.employee;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import teamfresh.api.application.company.domain.Company;
+
+/** 고객사 담당자 엔티티 */
+@Getter
+@Entity
+public class CustomerManager {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinTable(
+            name = "customer_company",
+            joinColumns = @JoinColumn(name = "company_id"),
+            inverseJoinColumns = @JoinColumn(name = "id")
+    )
+    private Company company;
+
+    @Column(length = 30)
+    private String name;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 100)
+    private String email;
+
+    @Column(length = 30)
+    private String department;
+
+    @Column(length = 20)
+    private String jobTitle;
+
+    protected CustomerManager() {
+    }
+
+    public CustomerManager(final Long id, final Company company, final String name, final String phone, final String email, final String department, final String jobTitle) {
+        this.id = id;
+        this.company = company;
+        this.name = name;
+        this.phone = phone;
+        this.email = email;
+        this.department = department;
+        this.jobTitle = jobTitle;
+    }
+}

--- a/src/main/java/teamfresh/api/application/company/employee/DeliveryMan.java
+++ b/src/main/java/teamfresh/api/application/company/employee/DeliveryMan.java
@@ -1,0 +1,50 @@
+package teamfresh.api.application.company.employee;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToOne;
+import lombok.Getter;
+import teamfresh.api.application.company.domain.Company;
+
+/** 운송사 기사 엔티티*/
+@Getter
+@Entity
+public class DeliveryMan {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinTable(
+            name = "carrier_company",
+            joinColumns = @JoinColumn(name = "company_id"),
+            inverseJoinColumns = @JoinColumn(name = "id")
+    )
+    private Company company;
+
+    @Column(length = 30)
+    private String name;
+
+    @Column(length = 20)
+    private String phone;
+
+    @Column(length = 20)
+    private String region;
+
+    protected DeliveryMan() {
+    }
+
+    public DeliveryMan(final Long id, final Company company, final String name, final String phone, final String region) {
+        this.id = id;
+        this.company = company;
+        this.name = name;
+        this.phone = phone;
+        this.region = region;
+    }
+}


### PR DESCRIPTION
회사정보를 관리하는 `Company`라는 엔티티를 추가합니다.
운송사의 기사님들을 관리할 `DeliveryMan`엔티티, 고객사의 담당자들을 관리할 `CustomerManager`엔티티를 추가했습니다.
`company_id`컬럼을 이용해 각각 조인 테이블을 사용해서 회사 엔티티와 연결됩니다.