### PR TITLE
이의제기 엔티티를 추가하라

### DIFF
--- a/src/main/java/teamfresh/api/application/penalty/objection/domain/Objection.java
+++ b/src/main/java/teamfresh/api/application/penalty/objection/domain/Objection.java
@@ -1,0 +1,37 @@
+package teamfresh.api.application.penalty.objection.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import lombok.Getter;
+import teamfresh.api.application.penalty.domain.Penalty;
+
+/** 페널티 이의제기 엔티티 */
+@Getter
+@Entity
+public class Objection {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "penalty_id")
+    private Penalty penalty;
+
+    @Column(length = 500)
+    private String content;
+
+    protected Objection() {}
+
+    public Objection(final Long id, final Penalty penalty, final String content) {
+        this.id = id;
+        this.penalty = penalty;
+        this.content = content;
+    }
+}

--- a/src/main/java/teamfresh/api/application/penalty/objection/domain/ObjectionRepository.java
+++ b/src/main/java/teamfresh/api/application/penalty/objection/domain/ObjectionRepository.java
@@ -1,0 +1,7 @@
+package teamfresh.api.application.penalty.objection.domain;
+
+
+import org.springframework.data.repository.CrudRepository;
+
+public interface ObjectionRepository extends CrudRepository<Objection, Long> {
+}


### PR DESCRIPTION
페널티를 발급받은 후 페널티에 대해 이의제기를 할 수 있습니다.
따라서 이의제기를 관리할 `Objection`엔티티를 만들었습니다.

페널티와 일대일 연관관계를 매핑했습니다.