### PR TITLE
VOC 목록 조회 응답에 이의제기 여부를 추가하라

### DIFF
--- a/src/main/java/teamfresh/api/application/penalty/domain/Penalty.java
+++ b/src/main/java/teamfresh/api/application/penalty/domain/Penalty.java
@@ -10,6 +10,8 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.OneToOne;
 import lombok.Getter;
 import teamfresh.api.application.compensation.domain.Compensation;
+import teamfresh.api.application.penalty.objection.domain.Objection;
+
 
 /** 페널티 엔티티 */
 @Getter
@@ -37,6 +39,9 @@ public class Penalty {
     /** 페널티 인정 여부 */
     @Column(columnDefinition = "tinyint")
     private Boolean confirmed;
+
+    @OneToOne(mappedBy = "penalty", fetch = FetchType.LAZY)
+    private Objection objection;
 
     protected Penalty() {
     }
@@ -69,5 +74,10 @@ public class Penalty {
     /** 페널티를 확인하면 read 상태를 true로 변경합니다. */
     public void read() {
         this.read = Boolean.TRUE;
+    }
+
+    /** 페널티에 대한 이의제기 */
+    public void object(Objection objection) {
+        this.objection = objection;
     }
 }

--- a/src/main/java/teamfresh/api/web/vocs/VocListController.java
+++ b/src/main/java/teamfresh/api/web/vocs/VocListController.java
@@ -93,12 +93,14 @@ public class VocListController {
                 private Long id;
                 private Boolean read;
                 private Boolean confirmed;
+                private Boolean objected;
 
                 public PenaltyDto(Penalty penalty) {
                     if (penalty != null) {
                         this.id = penalty.getId();
                         this.read = penalty.getRead();
                         this.confirmed = penalty.getConfirmed();
+                        this.objected = penalty.getObjection() != null;
                     }
                 }
             }


### PR DESCRIPTION
VOC 목록 조회 시 이의제기여부가 포함되어야 한다는 요구사항에 따라 `objected`라는 정보를 추가합니다.
페널티에 대해 이의제기를 한 경우 `true`, 하지 않은 경우 `false`입니다.