### PR TITLE
연관관계 매핑 편의 메서드를 활용해 VOC 등록 시 Blame도 함께 저장되게 하라

### DIFF
--- a/src/main/java/teamfresh/api/application/voc/domain/Voc.java
+++ b/src/main/java/teamfresh/api/application/voc/domain/Voc.java
@@ -1,5 +1,6 @@
 package teamfresh.api.application.voc.domain;
 
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -25,7 +26,7 @@ public class Voc {
     @Column(length = 500)
     private String content;
 
-    @OneToOne(fetch = FetchType.LAZY)
+    @OneToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
     @JoinColumn(name = "blame_id")
     private Blame blame;
 
@@ -49,16 +50,20 @@ public class Voc {
         this.createdBy = createdBy;
     }
 
-    public static Voc of(Long id, String content, Long createdBy) {
-        return new Voc(id, content, null, null, null, createdBy);
-    }
-
     public static Voc of(String content, Long createdBy) {
         return new Voc(null, content, null, null, null, createdBy);
     }
 
+    public static Voc of(String content, Long customerManagerId, Long createdBy) {
+        return new Voc(null, content, null, null, customerManagerId, createdBy);
+    }
+
     public static Voc of(String content, Blame blame, Long customerManagerId, Long createdBy) {
         return new Voc(null, content, blame, null, customerManagerId, createdBy);
+    }
+
+    public static Voc of(Long id, String content, Long createdBy) {
+        return new Voc(id, content, null, null, null, createdBy);
     }
 
     public static Voc of(Long id, String content, Blame blame, Long customerManagerId, Long createdBy) {
@@ -67,6 +72,13 @@ public class Voc {
 
     public static Voc of(Long id, String content, Blame blame, Compensation compensation, Long customerManagerId, Long createdBy) {
         return new Voc(id, content, blame, compensation, customerManagerId, createdBy);
+    }
+
+    /** 해당 VOC 건과 관련된 배귀책을 설정합니다. */
+    public void setBlame(Blame blame) {
+        if (blame != null) {
+            this.blame = blame;
+        }
     }
 
     /**

--- a/src/main/java/teamfresh/api/application/voc/service/VocCreator.java
+++ b/src/main/java/teamfresh/api/application/voc/service/VocCreator.java
@@ -5,7 +5,7 @@ import lombok.NoArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamfresh.api.application.voc.blame.service.BlameCreator;
+import teamfresh.api.application.voc.blame.domain.Blame;
 import teamfresh.api.application.voc.blame.domain.BlameTarget;
 import teamfresh.api.application.voc.domain.Voc;
 import teamfresh.api.application.voc.domain.VocRepository;
@@ -15,7 +15,6 @@ import teamfresh.api.application.voc.domain.VocRepository;
 @Service
 public class VocCreator {
 
-    private final BlameCreator blameCreator;
     private final VocRepository repository;
 
     /**
@@ -26,18 +25,21 @@ public class VocCreator {
      */
     @Transactional
     public Voc create(Command command) {
-        return repository.save(
-                Voc.of(
-                        command.content,
-                        blameCreator.create(
-                                command.target,
-                                command.targetCompanyId,
-                                command.cause
-                        ),
-                        command.customerManagerId,
-                        command.createdBy
+        Voc voc = Voc.of(
+                command.content,
+                command.customerManagerId,
+                command.createdBy
+        );
+
+        voc.setBlame(
+                Blame.of(
+                        command.target,
+                        command.targetCompanyId,
+                        command.cause
                 )
         );
+
+        return repository.save(voc);
     }
 
     /**

--- a/src/test/java/teamfresh/api/application/voc/service/VocCreatorTest.java
+++ b/src/test/java/teamfresh/api/application/voc/service/VocCreatorTest.java
@@ -8,7 +8,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import teamfresh.api.application.voc.blame.domain.Blame;
-import teamfresh.api.application.voc.blame.service.BlameCreator;
 import teamfresh.api.application.voc.blame.domain.BlameTarget;
 import teamfresh.api.application.voc.domain.Voc;
 import teamfresh.api.application.voc.domain.VocRepository;
@@ -23,9 +22,6 @@ class VocCreatorTest {
 
     @InjectMocks
     private VocCreator vocCreator;
-
-    @Mock
-    private BlameCreator blameCreator;
 
     @Mock
     private VocRepository vocRepository;
@@ -47,7 +43,6 @@ class VocCreatorTest {
         @DisplayName("VOC를 생성 후 반환한다")
         @Test
         void it_create_voc() {
-            given(blameCreator.create(target, targetCompanyId, cause)).willReturn(blame);
             given(vocRepository.save(any())).willReturn(voc);
 
             Voc savedVoc = vocCreator.create(


### PR DESCRIPTION
기존에는 VOC건에 대한 귀책을 설정할 때 BlameCreater를 이용해 먼저 저장한 후 VOC를 따로 저장하는 로직을 거쳤으나, 
연관관계 편의 메서드를 사용해 VOC 엔티티가 저장될 때 Blame도 저장되는 방식으로 변경합니다.

따라서 VocCreater 서비스에서 더이상 BlameCreater을 의존하지 않게됩니다.

귀책을 '설정'한다는 시나리오에 따라 `setBlame`이라는 메서드명을 사용했습니다.