### PR TITLE
VOC건에 이미 배상 정보가 등록되어있을 경우 예외를 던져라

### DIFF
--- a/src/main/java/teamfresh/api/application/compensation/exception/CompensationAlreadyExistException.java
+++ b/src/main/java/teamfresh/api/application/compensation/exception/CompensationAlreadyExistException.java
@@ -1,0 +1,8 @@
+package teamfresh.api.application.compensation.exception;
+
+/** VOC 건에 이미 배상 정보가 등록된 경우 던짐 */
+public class CompensationAlreadyExistException extends RuntimeException {
+    public CompensationAlreadyExistException() {
+        super("이미 존재하는 배상정보가 있습니다.");
+    }
+}

--- a/src/main/java/teamfresh/api/application/compensation/service/CompensationCreator.java
+++ b/src/main/java/teamfresh/api/application/compensation/service/CompensationCreator.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamfresh.api.application.compensation.domain.Compensation;
 import teamfresh.api.application.compensation.domain.CompensationRepository;
+import teamfresh.api.application.compensation.exception.CompensationAlreadyExistException;
 import teamfresh.api.application.voc.domain.Voc;
 import teamfresh.api.application.voc.service.VocReader;
 
@@ -26,6 +27,9 @@ public class CompensationCreator {
     @Transactional
     public Compensation create(Long vocId, int amount) {
         Voc voc = vocReader.read(vocId);
+        if (voc.getCompensation() != null) {
+            throw new CompensationAlreadyExistException();
+        }
 
         Compensation compensation = repository.save(
                 Compensation.of(amount)


### PR DESCRIPTION
VOC와 배상정보는 현재 일대일 연관관계이므로
이미 등록된 배상정보가 있다면 예외를 던집니다.