### PR TITLE
배상목록 조회 오류를 해결하라

### DIFF
--- a/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/Compensation.java
@@ -33,6 +33,7 @@ public class Compensation {
     private Compensation(final Long id, final int amount, final Voc voc, final Penalty penalty) {
         this.id = id;
         this.amount = amount;
+        this.voc = voc;
         this.penalty = penalty;
     }
 

--- a/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
+++ b/src/main/java/teamfresh/api/application/compensation/domain/CompensationRepository.java
@@ -9,7 +9,7 @@ public interface CompensationRepository extends CrudRepository<Compensation, Lon
 
     @Query(
             "select c from Compensation c " +
-                    "join fetch c.penalty"
+                    "join fetch c.voc"
     )
     List<Compensation> findAllWithFetch();
 }


### PR DESCRIPTION
Compenstaion 도메인의 생성자에서 voc를 입력받고 초기화하지 않던 부분을 고쳤습니다.
그리고 배상목록 조회 시 voc와 페치조인을 추가합니다.